### PR TITLE
Experimental: Git integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ require "simplecov"
 require "simplecov-buildkite"
 
 SimpleCov.start "rails" do
+  load_profile "buildkite"
+
   formatter SimpleCov::Formatter::MultiFormatter.new([
     SimpleCov::Formatter::HTMLFormatter,
     SimpleCov::Buildkite::AnnotationFormatter,
@@ -41,9 +43,9 @@ SimpleCov.start "rails" do
 end
 ```
 
-When run on Buildkite, this will also output a pretty Buildkite annotation:
+When run on Buildkite with the `"buildkite"` profile enabled, this will also output a pretty Buildkite annotation, with coverage change breakdowns for the current PR or branch and commit:
 
-<img width="473" alt="Buildkite build showing a SimpleCov report in a Buildkite annotation" src="https://user-images.githubusercontent.com/282113/40627591-b8de5bc4-6274-11e8-8483-245e35c873af.png">
+<img width="577" alt="Buildkite build showing a SimpleCov report in a Buildkite annotation" src="https://user-images.githubusercontent.com/282113/42116587-c2e9731e-7bac-11e8-9d2f-50fa7f071f09.png">
 
   [Rails]: https://rubyonrails.org
   [RSpec]: http://rspec.info

--- a/lib/simplecov/buildkite.rb
+++ b/lib/simplecov/buildkite.rb
@@ -5,3 +5,4 @@ end
 
 require "simplecov/buildkite/version"
 require "simplecov/buildkite/annotation_formatter"
+require "simplecov/buildkite/profiles"

--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -9,10 +9,12 @@ module SimpleCov::Buildkite
       message = <<~MESSAGE
         <h4>Coverage</h4>
         <dl class="flex mxn2">
-        #{git_results.reverse.map do |name, group|
+        #{git_results.to_a.reverse.map do |git_result|
+          name, group = git_result
+
           matches = name.match GIT_ANNOTATION_FORMAT_REGEX
 
-          title = "#{matches[:action] == "added" ? 'New Files' : 'Files Changed'} in #{changeset.include?('...') ? 'branch' : 'commit'}"
+          title = "#{matches[:action] == 'added' ? 'New Files' : 'Files Changed'} in #{changeset.include?('...') ? 'branch' : 'commit'}"
 
           format_as_metric(title, group, changeset: matches[:changeset])
         end}

--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -7,7 +7,8 @@ module SimpleCov::Buildkite
                                      .values_at(:git, :general)
 
       message = <<~MESSAGE
-        <h4>Coverage</h4>
+        #### Coverage
+
         <dl class="flex flex-wrap m1 mxn2">
       MESSAGE
 
@@ -41,13 +42,12 @@ module SimpleCov::Buildkite
 
       if general_results.any?
         message += <<~MESSAGE
-          <details>
-            <summary>Coverage Breakdown</summary>
-            <ul>
+          <details><summary>Coverage Breakdown</summary>
+
             #{general_results.map do |name, group|
-              "<li><strong>#{name}</strong>: #{format_group(group)}</li>"
+              "- **#{name}**: #{format_group(group)}"
             end.join("\n")}
-            </ul>
+
           </details>
         MESSAGE
       end
@@ -92,15 +92,20 @@ module SimpleCov::Buildkite
     end
 
     def format_as_metric(name, element, changeset: nil)
-      <<~METRIC_FORMAT
-        <div class="m2">
-          <dt#{changeset.nil? ? '' : " title=\"#{changeset}\""}>#{name}</dt>
-          <dd>
-            <span class="bold"><span class="h2 regular">#{format_float(element.covered_percent)}</span>%</span><br/>
-            #{format_line_count(element)}
-          </dd>
-        </div>
-      METRIC_FORMAT
+      metric = <<~METRIC_HEADER
+        <div class="m2"><dt#{changeset.nil? ? '' : " title=\"#{changeset}\""}>#{name}</dt><dd>
+      METRIC_HEADER
+
+      metric += <<~METRIC_VALUE
+
+        **<span class="h2 regular">#{format_float(element.covered_percent)}</span>%**  
+        #{format_line_count(element)}
+
+      METRIC_VALUE
+
+      metric += <<~METRIC_FOOTER
+        </dd></div>
+      METRIC_FOOTER
     end
 
     def format_group(element)

--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -8,7 +8,7 @@ module SimpleCov::Buildkite
 
       message = <<~MESSAGE
         <h4>Coverage</h4>
-        <dl class="flex mxn2">
+        <dl class="m1 mxn2 flex flex-wrap">
         #{git_results.to_a.reverse.map do |git_result|
           name, group = git_result
 
@@ -67,10 +67,10 @@ module SimpleCov::Buildkite
 
     def format_as_metric(name, element, changeset: nil)
       <<~METRIC_FORMAT
-        <div class="mx2">
+        <div class="m2">
           <dt title="#{changeset}">#{name}</dt>
           <dd>
-            <big><big>#{element.covered_percent.floor}</big></big>%<br/>
+            <big><big>#{element.covered_percent.round(2)}</big></big>%<br/>
             #{format_integer(element.covered_lines)} of #{format_integer(element.covered_lines + element.missed_lines)} lines<br/>
           </dd>
         </div>

--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -1,25 +1,55 @@
 module SimpleCov::Buildkite
   class AnnotationFormatter
     def format(result)
+      git_results, general_results = filter_git_groups(result.groups)
+                                     .values_at(:git, :general)
+
       message = <<~MESSAGE
         <details>
-        <summary>#{format_element(result)}</summary>
+          <summary>#{format_element(result)}</summary>
+          <ul>
+          #{ignore_empty_groups(general_results).map do |name, group|
+            "<li><strong>#{name}</strong>: #{format_element(group)}</li>"
+          end.join("\n")}
+          </ul>
+        </details>
         <ul>
-        #{result.groups.map do |name, group|
+        #{git_results.map do |name, group|
           "<li><strong>#{name}</strong>: #{format_element(group)}</li>"
         end.join("\n")}
         </ul>
-        </details>
       MESSAGE
 
-      if ENV["BUILDKITE"]
-        system "buildkite-agent", "annotate", "--context", "simplecov", "--style", "info", message
+      if ENV['BUILDKITE']
+        system 'buildkite-agent',
+               'annotate',
+               '--context', 'simplecov',
+               '--style', 'info',
+               message
       else
         puts message
       end
     end
 
     private
+
+    def ignore_empty_groups(groups)
+      groups.select do |_name, group|
+        (group.covered_lines + group.missed_lines).positive?
+      end
+    end
+
+    def filter_git_groups(groups)
+      groups.each_with_object(git: {}, general: {}) do |unzipped_group, cats|
+        name, group = unzipped_group
+
+        if name.match?(/^Files (?:added|changed) in [a-zA-Z0-9]+/)
+          cats[:git][name] = group
+        else
+          cats[:general][name] = group
+        end
+      end
+    end
 
     def format_element(element)
       "#{element.covered_percent.round(2)}% coverage: #{format_integer(element.covered_lines)} of #{format_integer(element.covered_lines + element.missed_lines)} lines"

--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -62,7 +62,11 @@ module SimpleCov::Buildkite
     end
 
     def format_integer(integer)
-      integer.to_s.gsub(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1,")
+      Kernel.format('%<integer>d', integer: integer).gsub(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1,")
+    end
+
+    def format_float(float)
+      Kernel.format('%<floored_float>g', floored_float: float.floor(2))
     end
 
     def format_as_metric(name, element, changeset: nil)
@@ -70,7 +74,7 @@ module SimpleCov::Buildkite
         <div class="m2">
           <dt title="#{changeset}">#{name}</dt>
           <dd>
-            <span class="bold"><span class="h2 regular">#{element.covered_percent.round(2)}</span>%</span><br/>
+            <span class="bold"><span class="h2 regular">#{format_float(element.covered_percent)}</span>%</span><br/>
             #{format_integer(element.covered_lines)} of #{format_integer(element.covered_lines + element.missed_lines)} lines<br/>
           </dd>
         </div>
@@ -78,7 +82,7 @@ module SimpleCov::Buildkite
     end
 
     def format_element(element)
-      "#{element.covered_percent.round(2)}% coverage: #{format_integer(element.covered_lines)} of #{format_integer(element.covered_lines + element.missed_lines)} lines"
+      "#{format_float(element.covered_percent)}% coverage: #{format_integer(element.covered_lines)} of #{format_integer(element.covered_lines + element.missed_lines)} lines"
     end
   end
 end

--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -65,7 +65,7 @@ module SimpleCov::Buildkite
       integer.to_s.gsub(/(\d)(?=(\d\d\d)+(?!\d))/, "\\1,")
     end
 
-    def format_as_metric(name, element, changeset:)
+    def format_as_metric(name, element, changeset: nil)
       <<~METRIC_FORMAT
         <div class="mx2">
           <dt title="#{changeset}">#{name}</dt>

--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -17,7 +17,7 @@ module SimpleCov::Buildkite
           title = "#{matches[:action] == 'added' ? 'New Files' : 'Files Changed'} in #{matches[:changeset].include?('...') ? 'branch' : 'commit'}"
 
           format_as_metric(title, group, changeset: matches[:changeset])
-        end}
+        end.join("\n")}
         #{format_as_metric('All Files', result)}
         </dl>
         <details>

--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -8,7 +8,7 @@ module SimpleCov::Buildkite
 
       message = <<~MESSAGE
         <h4>Coverage</h4>
-        <dl class="m1 mxn2 flex flex-wrap">
+        <dl class="flex flex-wrap m1 mxn2">
         #{git_results.to_a.reverse.map do |git_result|
           name, group = git_result
 
@@ -70,7 +70,7 @@ module SimpleCov::Buildkite
         <div class="m2">
           <dt title="#{changeset}">#{name}</dt>
           <dd>
-            <big><big>#{element.covered_percent.round(2)}</big></big>%<br/>
+            <span class="bold"><span class="h2 regular">#{element.covered_percent.round(2)}</span>%</span><br/>
             #{format_integer(element.covered_lines)} of #{format_integer(element.covered_lines + element.missed_lines)} lines<br/>
           </dd>
         </div>

--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -94,10 +94,10 @@ module SimpleCov::Buildkite
     def format_as_metric(name, element, changeset: nil)
       <<~METRIC_FORMAT
         <div class="m2">
-          <dt title="#{changeset}">#{name}</dt>
+          <dt#{changeset.nil? ? '' : " title=\"#{changeset}\""}>#{name}</dt>
           <dd>
             <span class="bold"><span class="h2 regular">#{format_float(element.covered_percent)}</span>%</span><br/>
-            #{format_line_count(element)}<br/>
+            #{format_line_count(element)}
           </dd>
         </div>
       METRIC_FORMAT

--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -14,7 +14,7 @@ module SimpleCov::Buildkite
 
           matches = name.match GIT_ANNOTATION_FORMAT_REGEX
 
-          title = "#{matches[:action] == 'added' ? 'New Files' : 'Files Changed'} in #{changeset.include?('...') ? 'branch' : 'commit'}"
+          title = "#{matches[:action] == 'added' ? 'New Files' : 'Files Changed'} in #{matches[:changeset].include?('...') ? 'branch' : 'commit'}"
 
           format_as_metric(title, group, changeset: matches[:changeset])
         end}

--- a/lib/simplecov/buildkite/profiles.rb
+++ b/lib/simplecov/buildkite/profiles.rb
@@ -54,8 +54,7 @@ module SimpleCov::Buildkite::Profiles
     STDERR.puts "current_commit_short=#{current_commit_short}"
 
     changed_files_in_commit = git_diff_names(current_commit,
-                                             "#{current_commit}^",
-                                             diff_filter: 'd') # show all change types except deletion
+                                             diff_filter: 'd')
 
     STDERR.puts "changed_files_in_commit.count=#{changed_files_in_commit.count}"
 
@@ -66,8 +65,7 @@ module SimpleCov::Buildkite::Profiles
     end
 
     added_files_in_commit = git_diff_names(current_commit,
-                                           "#{current_commit}^",
-                                           diff_filter: 'A') # only show newly added files
+                                           diff_filter: 'A')
 
     STDERR.puts "added_files_in_commit.count=#{added_files_in_commit.count}"
 
@@ -87,9 +85,9 @@ module SimpleCov::Buildkite::Profiles
       STDERR.puts "merge_base=#{merge_base}"
       STDERR.puts "merge_base_short=#{merge_base_short}"
 
-      changed_files_in_branch = git_diff_names(current_commit,
-                                               merge_base,
-                                               diff_filter: 'd') # show all change types except deletion
+      changed_files_in_branch = git_diff_names(merge_base,
+                                               current_commit,
+                                               diff_filter: 'd')
 
       STDERR.puts "changed_files_in_branch.count=#{changed_files_in_branch.count}"
 
@@ -99,9 +97,9 @@ module SimpleCov::Buildkite::Profiles
         end
       end
 
-      added_files_in_branch = git_diff_names(current_commit,
-                                             merge_base,
-                                             diff_filter: 'A') # only show newly added files
+      added_files_in_branch = git_diff_names(merge_base,
+                                             current_commit,
+                                             diff_filter: 'A')
 
       STDERR.puts "added_files_in_branch.count=#{added_files_in_branch.count}"
 

--- a/lib/simplecov/buildkite/profiles.rb
+++ b/lib/simplecov/buildkite/profiles.rb
@@ -4,6 +4,7 @@ require 'English'
 
 module SimpleCov::Buildkite::Profiles
   SimpleCov.profiles.define 'buildkite' do
+    STDERR.puts 'SimpleCov::Buildkite profile initialising...'
     return unless ENV['BUILDKITE'] == 'true'
 
     base_branch_name = (
@@ -11,9 +12,13 @@ module SimpleCov::Buildkite::Profiles
       ENV['BUILDKITE_PIPELINE_DEFAULT_BRANCH']
     )
 
+    STDERR.puts "base_branch_name=#{base_branch_name}"
+
     if base_branch_name.nil?
       changed_files = `git diff --name-only HEAD HEAD^`.split "\n"
       return unless $CHILD_STATUS == 0
+
+      STDERR.puts "changed_files=#{changed_files}"
 
       add_group "Changed in #{ENV['BUILDKITE_COMMIT'] || 'this commit'}" do |tested_file|
         changed_files.detect do |changed_file|

--- a/lib/simplecov/buildkite/profiles.rb
+++ b/lib/simplecov/buildkite/profiles.rb
@@ -23,7 +23,7 @@ module SimpleCov::Buildkite::Profiles
                           'diff',
                           '--name-only',
                           'HEAD',
-                          'HEAD^').split "\n"
+                          'HEAD^').chomp.split "\n"
 
       STDERR.puts "changed_files=#{changed_files}"
 
@@ -42,14 +42,17 @@ module SimpleCov::Buildkite::Profiles
       merge_base = run('git',
                        'merge-base',
                        'HEAD',
-                       base_branch_name)
+                       base_branch_name).chomp
+
+      STDERR.puts "merge_base=#{merge_base}"
 
       changed_files = run('git',
                           'diff',
                           '--name-only',
                           'HEAD',
-                          merge_base).split "\n"
-      return unless $CHILD_STATUS == 0
+                          merge_base).chomp.split "\n"
+
+      STDERR.puts "changed_files.count=#{changed_files.count}"
 
       add_group "Changed from #{base_branch_name}" do |tested_file|
         changed_files.detect do |changed_file|

--- a/lib/simplecov/buildkite/profiles.rb
+++ b/lib/simplecov/buildkite/profiles.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'English'
+
+module SimpleCov::Buildkite::Profiles
+  SimpleCov.profiles.define 'buildkite' do
+    return unless ENV['BUILDKITE'] == 'true'
+
+    base_branch_name = (
+      ENV['BUILDKITE_PULL_REQUEST_BASE_BRANCH'] ||
+      ENV['BUILDKITE_PIPELINE_DEFAULT_BRANCH']
+    )
+
+    if base_branch_name.nil?
+      changed_files = `git diff --name-only HEAD HEAD^`.split "\n"
+      return unless $CHILD_STATUS == 0
+
+      add_group "Changed in #{ENV['BUILDKITE_COMMIT'] || 'this commit'}" do |tested_file|
+        changed_files.detect do |changed_file|
+          tested_file.filename.ends_with?(changed_file)
+        end
+      end
+    else
+      `git merge-base --is-ancestor #{base_branch_name} HEAD`
+      return unless $CHILD_STATUS == 0
+
+      merge_base = `git merge-base HEAD #{base_branch_name}`
+      return unless $CHILD_STATUS == 0
+
+      changed_files = `git diff --name-only HEAD #{merge_base}`.split "\n"
+      return unless $CHILD_STATUS == 0
+
+      add_group "Changed from #{base_branch_name}" do |tested_file|
+        changed_files.detect do |changed_file|
+          tested_file.filename.ends_with?(changed_file)
+        end
+      end
+    end
+  end
+end

--- a/lib/simplecov/buildkite/profiles.rb
+++ b/lib/simplecov/buildkite/profiles.rb
@@ -29,21 +29,22 @@ module SimpleCov::Buildkite::Profiles
 
     STDERR.puts "current_commit_short=#{current_commit_short}"
 
-    if base_branch_name.nil?
-      changed_files = run('git',
-                          'diff',
-                          '--name-only',
-                          current_commit,
-                          "#{current_commit}^").split "\n"
+    changed_files_in_commit = run('git',
+                                  'diff',
+                                  '--name-only',
+                                  '--diff-filter=d',
+                                  current_commit,
+                                  "#{current_commit}^").split "\n"
 
-      STDERR.puts "changed_files=#{changed_files}"
+    STDERR.puts "changed_files_in_commit=#{changed_files_in_commit}"
 
-      add_group "Changed in #{current_commit_short}" do |tested_file|
-        changed_files.detect do |changed_file|
-          tested_file.filename.ends_with?(changed_file)
-        end
+    add_group "Files changed in #{current_commit_short}" do |tested_file|
+      changed_files_in_commit.detect do |changed_file|
+        tested_file.filename.ends_with?(changed_file)
       end
-    else
+    end
+
+    if base_branch_name
       merge_base = run('git',
                        'merge-base',
                        current_commit,
@@ -57,16 +58,17 @@ module SimpleCov::Buildkite::Profiles
       STDERR.puts "merge_base=#{merge_base}"
       STDERR.puts "merge_base_short=#{merge_base_short}"
 
-      changed_files = run('git',
-                          'diff',
-                          '--name-only',
-                          current_commit,
-                          merge_base).split "\n"
+      changed_files_in_branch = run('git',
+                                    'diff',
+                                    '--name-only',
+                                    '--diff-filter=d',
+                                    current_commit,
+                                    merge_base).split "\n"
 
-      STDERR.puts "changed_files.count=#{changed_files.count}"
+      STDERR.puts "changed_files_in_branch.count=#{changed_files_in_branch.count}"
 
-      add_group "Changed in #{merge_base_short}...#{current_commit_short}" do |tested_file|
-        changed_files.detect do |changed_file|
+      add_group "Files changed in #{merge_base_short}...#{current_commit_short}" do |tested_file|
+        changed_files_in_branch.detect do |changed_file|
           tested_file.filename.ends_with?(changed_file)
         end
       end

--- a/lib/simplecov/buildkite/profiles.rb
+++ b/lib/simplecov/buildkite/profiles.rb
@@ -33,11 +33,11 @@ module SimpleCov::Buildkite::Profiles
         end
       end
     else
-      run('git',
-          'merge-base',
-          '--is-ancestor',
-          base_branch_name,
-          'HEAD')
+      # run('git',
+      #     'merge-base',
+      #     '--is-ancestor',
+      #     base_branch_name,
+      #     'HEAD')
 
       merge_base = run('git',
                        'merge-base',

--- a/lib/simplecov/buildkite/profiles.rb
+++ b/lib/simplecov/buildkite/profiles.rb
@@ -38,10 +38,10 @@ module SimpleCov::Buildkite::Profiles
 
     STDERR.puts "branch_name=#{branch_name}"
 
-    base_branch_name = (
-      ENV['BUILDKITE_PULL_REQUEST_BASE_BRANCH'] ||
-      ENV['BUILDKITE_PIPELINE_DEFAULT_BRANCH']
-    )
+    base_branch_name = ENV['BUILDKITE_PULL_REQUEST_BASE_BRANCH']
+    if base_branch_name.nil? || base_branch_name.empty?
+      base_branch_name = ENV['BUILDKITE_PIPELINE_DEFAULT_BRANCH']
+    end
 
     STDERR.puts "base_branch_name=#{base_branch_name}"
 

--- a/spec/simplecov/buildkite/annotation_formatter_spec.rb
+++ b/spec/simplecov/buildkite/annotation_formatter_spec.rb
@@ -15,10 +15,10 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
         <h4>Coverage</h4>
         <dl class="flex flex-wrap m1 mxn2">
         <div class="m2">
-          <dt title="">All Files</dt>
+          <dt>All Files</dt>
           <dd>
             <span class="bold"><span class="h2 regular">100</span>%</span><br/>
-            0 of 0 lines<br/>
+            0 of 0 lines
           </dd>
         </div>
         </dl>
@@ -34,10 +34,10 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
         <h4>Coverage</h4>
         <dl class="flex flex-wrap m1 mxn2">
         <div class="m2">
-          <dt title="">All Files</dt>
+          <dt>All Files</dt>
           <dd>
             <span class="bold"><span class="h2 regular">100</span>%</span><br/>
-            0 of 0 lines<br/>
+            0 of 0 lines
           </dd>
         </div>
         </dl>

--- a/spec/simplecov/buildkite/annotation_formatter_spec.rb
+++ b/spec/simplecov/buildkite/annotation_formatter_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
         <div class="m2">
           <dt title="">All Files</dt>
           <dd>
-            <span class="bold"><span class="h2 regular">100.0</span>%</span><br/>
-            0.0 of 0.0 lines<br/>
+            <span class="bold"><span class="h2 regular">100</span>%</span><br/>
+            0 of 0 lines<br/>
           </dd>
         </div>
         
@@ -45,8 +45,8 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
         <div class="m2">
           <dt title="">All Files</dt>
           <dd>
-            <span class="bold"><span class="h2 regular">100.0</span>%</span><br/>
-            0.0 of 0.0 lines<br/>
+            <span class="bold"><span class="h2 regular">100</span>%</span><br/>
+            0 of 0 lines<br/>
           </dd>
         </div>
         

--- a/spec/simplecov/buildkite/annotation_formatter_spec.rb
+++ b/spec/simplecov/buildkite/annotation_formatter_spec.rb
@@ -13,12 +13,12 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
     it 'outputs a nicely formatter annotation' do
       expect { formatter.format(result) }.to output(<<~MESSAGE).to_stdout
         <h4>Coverage</h4>
-        <dl class="flex mxn2">
+        <dl class="m1 mxn2 flex flex-wrap">
 
-        <div class="mx2">
+        <div class="m2">
           <dt title="">All Files</dt>
           <dd>
-            <big><big>100</big></big>%<br/>
+            <big><big>100.0</big></big>%<br/>
             0.0 of 0.0 lines<br/>
           </dd>
         </div>
@@ -40,12 +40,12 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
     it 'creates a nicely formatted annotation' do
       expect(formatter).to receive(:system).with('buildkite-agent', 'annotate', '--context', 'simplecov', '--style', 'info', <<~MESSAGE)
         <h4>Coverage</h4>
-        <dl class="flex mxn2">
+        <dl class="m1 mxn2 flex flex-wrap">
 
-        <div class="mx2">
+        <div class="m2">
           <dt title="">All Files</dt>
           <dd>
-            <big><big>100</big></big>%<br/>
+            <big><big>100.0</big></big>%<br/>
             0.0 of 0.0 lines<br/>
           </dd>
         </div>

--- a/spec/simplecov/buildkite/annotation_formatter_spec.rb
+++ b/spec/simplecov/buildkite/annotation_formatter_spec.rb
@@ -14,7 +14,6 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
       expect { formatter.format(result) }.to output(<<~MESSAGE).to_stdout
         <h4>Coverage</h4>
         <dl class="flex flex-wrap m1 mxn2">
-
         <div class="m2">
           <dt title="">All Files</dt>
           <dd>
@@ -22,14 +21,7 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
             0 of 0 lines<br/>
           </dd>
         </div>
-        
         </dl>
-        <details>
-          <summary>Coverage Breakdown</summary>
-          <ul>
-          
-          </ul>
-        </details>
       MESSAGE
     end
   end
@@ -41,7 +33,6 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
       expect(formatter).to receive(:system).with('buildkite-agent', 'annotate', '--context', 'simplecov', '--style', 'info', <<~MESSAGE)
         <h4>Coverage</h4>
         <dl class="flex flex-wrap m1 mxn2">
-
         <div class="m2">
           <dt title="">All Files</dt>
           <dd>
@@ -49,14 +40,7 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
             0 of 0 lines<br/>
           </dd>
         </div>
-        
         </dl>
-        <details>
-          <summary>Coverage Breakdown</summary>
-          <ul>
-          
-          </ul>
-        </details>
       MESSAGE
 
       formatter.format(result)

--- a/spec/simplecov/buildkite/annotation_formatter_spec.rb
+++ b/spec/simplecov/buildkite/annotation_formatter_spec.rb
@@ -12,15 +12,15 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
 
     it 'emits a nicely formatted annotation to STDOUT' do
       expect { formatter.format(result) }.to output(<<~MESSAGE).to_stdout
-        <h4>Coverage</h4>
+        #### Coverage
+
         <dl class="flex flex-wrap m1 mxn2">
-        <div class="m2">
-          <dt>All Files</dt>
-          <dd>
-            <span class="bold"><span class="h2 regular">100</span>%</span><br/>
-            0 of 0 lines
-          </dd>
-        </div>
+        <div class="m2"><dt>All Files</dt><dd>
+
+        **<span class="h2 regular">100</span>%**  
+        0 of 0 lines
+
+        </dd></div>
         </dl>
       MESSAGE
     end
@@ -31,15 +31,15 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
 
     it 'submits a nicely formatted annotation to the Agent' do
       expect(formatter).to receive(:system).with('buildkite-agent', 'annotate', '--context', 'simplecov', '--style', 'info', <<~MESSAGE)
-        <h4>Coverage</h4>
+        #### Coverage
+
         <dl class="flex flex-wrap m1 mxn2">
-        <div class="m2">
-          <dt>All Files</dt>
-          <dd>
-            <span class="bold"><span class="h2 regular">100</span>%</span><br/>
-            0 of 0 lines
-          </dd>
-        </div>
+        <div class="m2"><dt>All Files</dt><dd>
+
+        **<span class="h2 regular">100</span>%**  
+        0 of 0 lines
+
+        </dd></div>
         </dl>
       MESSAGE
 

--- a/spec/simplecov/buildkite/annotation_formatter_spec.rb
+++ b/spec/simplecov/buildkite/annotation_formatter_spec.rb
@@ -1,4 +1,4 @@
-require "spec_helper"
+require 'spec_helper'
 
 RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
   let(:result) { SimpleCov::Result.from_hash("RSpec" => {"coverage" => {"a.rb" => [1, 0], "b.rb" => [0, 1]}, "timestamp" => 1527643747}) }
@@ -7,40 +7,56 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
 
   before { allow(SimpleCov).to receive(:groups).and_return("a" => "a", "b" => "b") }
 
-  context "outside of buildkite" do
-    around { |example| stubbing_env("BUILDKITE", nil) { example.call } }
+  context 'outside of buildkite' do
+    around { |example| stubbing_env('BUILDKITE', nil) { example.call } }
 
-    it "outputs a nicely formatter annotation" do
+    it 'outputs a nicely formatter annotation' do
       expect { formatter.format(result) }.to output(<<~MESSAGE).to_stdout
+        <h4>Coverage</h4>
+        <dl class="flex mxn2">
+
+        <div class="mx2">
+          <dt title="">All Files</dt>
+          <dd>
+            <big><big>100</big></big>%<br/>
+            0.0 of 0.0 lines<br/>
+          </dd>
+        </div>
+        
+        </dl>
         <details>
-          <summary>100.0% coverage: 0.0 of 0.0 lines</summary>
+          <summary>Coverage Breakdown</summary>
           <ul>
-            <li><strong>a</strong>: 100.0% coverage: 0.0 of 0.0 lines</li>
-        <li><strong>b</strong>: 100.0% coverage: 0.0 of 0.0 lines</li>
+          
           </ul>
         </details>
-        <ul>
-          
-        </ul>
       MESSAGE
     end
   end
 
-  context "inside buildkite" do
-    around { |example| stubbing_env("BUILDKITE", "true") { example.call } }
+  context 'inside buildkite' do
+    around { |example| stubbing_env('BUILDKITE', 'true') { example.call } }
 
-    it "creates a nicely formatted annotation" do
-      expect(formatter).to receive(:system).with("buildkite-agent", "annotate", "--context", "simplecov", "--style", "info", <<~MESSAGE)
+    it 'creates a nicely formatted annotation' do
+      expect(formatter).to receive(:system).with('buildkite-agent', 'annotate', '--context', 'simplecov', '--style', 'info', <<~MESSAGE)
+        <h4>Coverage</h4>
+        <dl class="flex mxn2">
+
+        <div class="mx2">
+          <dt title="">All Files</dt>
+          <dd>
+            <big><big>100</big></big>%<br/>
+            0.0 of 0.0 lines<br/>
+          </dd>
+        </div>
+        
+        </dl>
         <details>
-          <summary>100.0% coverage: 0.0 of 0.0 lines</summary>
+          <summary>Coverage Breakdown</summary>
           <ul>
-            <li><strong>a</strong>: 100.0% coverage: 0.0 of 0.0 lines</li>
-        <li><strong>b</strong>: 100.0% coverage: 0.0 of 0.0 lines</li>
+          
           </ul>
         </details>
-        <ul>
-          
-        </ul>
       MESSAGE
 
       formatter.format(result)

--- a/spec/simplecov/buildkite/annotation_formatter_spec.rb
+++ b/spec/simplecov/buildkite/annotation_formatter_spec.rb
@@ -13,12 +13,15 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
     it "outputs a nicely formatter annotation" do
       expect { formatter.format(result) }.to output(<<~MESSAGE).to_stdout
         <details>
-        <summary>100.0% coverage: 0.0 of 0.0 lines</summary>
-        <ul>
-        <li><strong>a</strong>: 100.0% coverage: 0.0 of 0.0 lines</li>
+          <summary>100.0% coverage: 0.0 of 0.0 lines</summary>
+          <ul>
+            <li><strong>a</strong>: 100.0% coverage: 0.0 of 0.0 lines</li>
         <li><strong>b</strong>: 100.0% coverage: 0.0 of 0.0 lines</li>
-        </ul>
+          </ul>
         </details>
+        <ul>
+          
+        </ul>
       MESSAGE
     end
   end
@@ -29,12 +32,15 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
     it "creates a nicely formatted annotation" do
       expect(formatter).to receive(:system).with("buildkite-agent", "annotate", "--context", "simplecov", "--style", "info", <<~MESSAGE)
         <details>
-        <summary>100.0% coverage: 0.0 of 0.0 lines</summary>
-        <ul>
-        <li><strong>a</strong>: 100.0% coverage: 0.0 of 0.0 lines</li>
+          <summary>100.0% coverage: 0.0 of 0.0 lines</summary>
+          <ul>
+            <li><strong>a</strong>: 100.0% coverage: 0.0 of 0.0 lines</li>
         <li><strong>b</strong>: 100.0% coverage: 0.0 of 0.0 lines</li>
-        </ul>
+          </ul>
         </details>
+        <ul>
+          
+        </ul>
       MESSAGE
 
       formatter.format(result)

--- a/spec/simplecov/buildkite/annotation_formatter_spec.rb
+++ b/spec/simplecov/buildkite/annotation_formatter_spec.rb
@@ -10,15 +10,15 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
   context 'outside of buildkite' do
     around { |example| stubbing_env('BUILDKITE', nil) { example.call } }
 
-    it 'outputs a nicely formatter annotation' do
+    it 'emits a nicely formatted annotation to STDOUT' do
       expect { formatter.format(result) }.to output(<<~MESSAGE).to_stdout
         <h4>Coverage</h4>
-        <dl class="m1 mxn2 flex flex-wrap">
+        <dl class="flex flex-wrap m1 mxn2">
 
         <div class="m2">
           <dt title="">All Files</dt>
           <dd>
-            <big><big>100.0</big></big>%<br/>
+            <span class="bold"><span class="h2 regular">100.0</span>%</span><br/>
             0.0 of 0.0 lines<br/>
           </dd>
         </div>
@@ -34,18 +34,18 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
     end
   end
 
-  context 'inside buildkite' do
+  context 'inside Buildkite' do
     around { |example| stubbing_env('BUILDKITE', 'true') { example.call } }
 
-    it 'creates a nicely formatted annotation' do
+    it 'submits a nicely formatted annotation to the Agent' do
       expect(formatter).to receive(:system).with('buildkite-agent', 'annotate', '--context', 'simplecov', '--style', 'info', <<~MESSAGE)
         <h4>Coverage</h4>
-        <dl class="m1 mxn2 flex flex-wrap">
+        <dl class="flex flex-wrap m1 mxn2">
 
         <div class="m2">
           <dt title="">All Files</dt>
           <dd>
-            <big><big>100.0</big></big>%<br/>
+            <span class="bold"><span class="h2 regular">100.0</span>%</span><br/>
             0.0 of 0.0 lines<br/>
           </dd>
         </div>


### PR DESCRIPTION
This adds a profile definition which, when loaded, generates groups based on the files which have been changed in source control, in both the branch and the current commit, if relevant. It also updates the formatter to explicitly handle these groups, calling them out with prominence in the UI

<img width="577" alt="screen shot 2018-06-29 at 2 57 08 pm" src="https://user-images.githubusercontent.com/282113/42116587-c2e9731e-7bac-11e8-9d2f-50fa7f071f09.png">

“New files in branch” gives coverage of newly created files based on a file comparison with either the target branch, or the primary branch, depending on what context is known. “Files changed in branch” includes all files which have been either created or updated in the branch.

The goal is to make it compare pull requests to their target branches, and to compare changes in normal branches to either the primary branch, or to the prior commit.

This uses the newly added Basscss classes in the annotation gear to present the UI in a nice, simple way.