### PR TITLE
Write annotations to file if SIMPLECOV_BUILDKITE_TOFILE is true

### DIFF
--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -14,6 +14,8 @@ module SimpleCov::Buildkite
 
       if ENV["BUILDKITE"]
         system "buildkite-agent", "annotate", "--context", "simplecov", "--style", "info", message
+      elsif ENV["SIMPLECOV_BUILDKITE_TOFILE"]
+        IO.write("coverage/buildkite-annotations.html", message)
       else
         puts message
       end

--- a/spec/simplecov/buildkite/annotation_formatter_spec.rb
+++ b/spec/simplecov/buildkite/annotation_formatter_spec.rb
@@ -23,6 +23,28 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
     end
   end
 
+  context "outside of buildkite, when SIMPLECOV_BUILDKITE_TOFILE is set to true" do
+    before { allow(IO).to receive(:write) }
+
+    around { |example| stubbing_env("BUILDKITE", nil) { example.call } }
+    around { |example| stubbing_env("SIMPLECOV_BUILDKITE_TOFILE", 'true') { example.call } }
+
+    message = <<~MESSAGE
+      <details>
+      <summary>100.0% coverage: 0.0 of 0.0 lines</summary>
+      <ul>
+      <li><strong>a</strong>: 100.0% coverage: 0.0 of 0.0 lines</li>
+      <li><strong>b</strong>: 100.0% coverage: 0.0 of 0.0 lines</li>
+      </ul>
+      </details>
+    MESSAGE
+
+    it "outputs to file" do
+      expect(IO).to receive(:write).with("coverage/buildkite-annotations.html", message)
+      formatter.format(result)
+    end
+  end
+
   context "inside buildkite" do
     around { |example| stubbing_env("BUILDKITE", "true") { example.call } }
 


### PR DESCRIPTION
Hi there.

I was looking for a way to surface our simplecov coverage in our buildkite pipelines and came across this gem.

It almost does exactly what I want.

The issue I have is that because our tests run within a docker container, we can't annotate the pipeline directly - `buildkite-agent` isn't running on the container where the tests are run.

Rather than add the `buildkite-agent` tooling to our container. I thought it might be useful to allow this gem to write it's results to a file if a certain ENV variable was set.

This way the file containing the simplecov-buildkite results can be uploaded as a buildkite artifact. Subsequent steps can downloaded that artifact and annotate the pipeline using it's content.

Along the lines of:
```
    command: |
      buildkite-agent artifact download coverage/buildkite-annotations.html /tmp/
      cat /tmp/coverage/buildkite-annotations.html | buildkite-agent annotate --context simplecov --style info
```

I've tried to stick to the coding style already used here and have added a test for the new use case. 

Please let me know if you'd like me to make some changes to the PR or if this feature is totally off base.