### PR TITLE
Use core `String#end_with?` method instead of ActiveSupport `ends_with?` extension

### DIFF
--- a/lib/simplecov/buildkite/profiles.rb
+++ b/lib/simplecov/buildkite/profiles.rb
@@ -60,7 +60,7 @@ module SimpleCov::Buildkite::Profiles
 
     add_group "Files changed in #{current_commit_short}" do |tested_file|
       changed_files_in_commit.detect do |changed_file|
-        tested_file.filename.ends_with?(changed_file)
+        tested_file.filename.end_with?(changed_file)
       end
     end
 
@@ -71,7 +71,7 @@ module SimpleCov::Buildkite::Profiles
 
     add_group "Files added in #{current_commit_short}" do |tested_file|
       added_files_in_commit.detect do |added_file|
-        tested_file.filename.ends_with?(added_file)
+        tested_file.filename.end_with?(added_file)
       end
     end
 
@@ -93,7 +93,7 @@ module SimpleCov::Buildkite::Profiles
 
       add_group "Files changed in #{merge_base_short}...#{current_commit_short}" do |tested_file|
         changed_files_in_branch.detect do |changed_file|
-          tested_file.filename.ends_with?(changed_file)
+          tested_file.filename.end_with?(changed_file)
         end
       end
 
@@ -105,7 +105,7 @@ module SimpleCov::Buildkite::Profiles
 
       add_group "Files added in #{merge_base_short}...#{current_commit_short}" do |tested_file|
         added_files_in_branch.detect do |added_file|
-          tested_file.filename.ends_with?(added_file)
+          tested_file.filename.end_with?(added_file)
         end
       end
     end


### PR DESCRIPTION
Hello @ticky!

I just discovered this project of yours and it's great! I set up the `git-integration` branch within my Buildkite pipeline, but to do so, I needed to switch the usages of the AcrtiveSupport `#ends_with?` extension to the the Ruby core `String#end_with?`method, because I don't have ActiveSupport installed within this particular project.

Would you mind pulling in this change?

While I have you here, I'd definitely encourage you to ship this when you get the chance: it seems to work great and it's _really helpful_ to see the current branch's coverage number front and centre 😄 

Thanks for creating simplecov-buildkite! 🙏 

 