### PR TITLE
Use sentence case in coverage annotation headers

### DIFF
--- a/lib/simplecov/buildkite/annotation_formatter.rb
+++ b/lib/simplecov/buildkite/annotation_formatter.rb
@@ -18,9 +18,9 @@ module SimpleCov::Buildkite
         matches = name.match GIT_ANNOTATION_FORMAT_REGEX
 
         type = if matches[:action] == 'added'
-                 'New Files'
+                 'New files'
                else
-                 'Files Changed'
+                 'Files changed'
                end
 
         changeset = if matches[:changeset].include?('...')
@@ -34,7 +34,7 @@ module SimpleCov::Buildkite
                                     changeset: matches[:changeset]
       end
 
-      message += format_as_metric 'All Files', result
+      message += format_as_metric 'All files', result
 
       message += <<~MESSAGE
         </dl>
@@ -42,7 +42,7 @@ module SimpleCov::Buildkite
 
       if general_results.any?
         message += <<~MESSAGE
-          <details><summary>Coverage Breakdown</summary>
+          <details><summary>Coverage breakdown</summary>
 
             #{general_results.map do |name, group|
               "- **#{name}**: #{format_group(group)}"

--- a/spec/simplecov/buildkite/annotation_formatter_spec.rb
+++ b/spec/simplecov/buildkite/annotation_formatter_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
         #### Coverage
 
         <dl class="flex flex-wrap m1 mxn2">
-        <div class="m2"><dt>All Files</dt><dd>
+        <div class="m2"><dt>All files</dt><dd>
 
         **<span class="h2 regular">100</span>%**  
         0 of 0 lines
@@ -34,7 +34,7 @@ RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
         #### Coverage
 
         <dl class="flex flex-wrap m1 mxn2">
-        <div class="m2"><dt>All Files</dt><dd>
+        <div class="m2"><dt>All files</dt><dd>
 
         **<span class="h2 regular">100</span>%**  
         0 of 0 lines


### PR DESCRIPTION
I feel this reads more naturally given that the headers are usually shown with the “in branch” or “in commit” text afterwards, so now it reads “Files changed in commit”.

This a much more subjective PR than my previous one (#8) but I do think it is a subtle improvement to usability 😄

That said, I'm not sure if you're following a particular style guide for your text copy, so I'm happy to defer to your judgement as to whether this feels right to bring in.

Here's how it looks with this change incorporated:

<img width="1171" alt="Screen Shot 2020-05-15 at 1 29 24 pm" src="https://user-images.githubusercontent.com/3134/82008464-23f6aa80-96b0-11ea-9cf7-a40694906f36.png">
