### PR TITLE
SimpleCov 0.19 compatibility in specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: false
 language: ruby
 rvm:
-  - 2.5.1
-before_install: gem install bundler -v 1.16.2
+  - 2.6.5
+before_install: gem install bundler -v 1.17.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     diff-lcs (1.3)
-    docile (1.3.1)
-    json (2.3.1)
+    docile (1.3.2)
     rake (13.0.1)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
@@ -24,11 +23,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    simplecov (0.16.1)
+    simplecov (0.19.0)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+    simplecov-html (0.12.2)
 
 PLATFORMS
   ruby
@@ -40,4 +38,4 @@ DEPENDENCIES
   simplecov-buildkite!
 
 BUNDLED WITH
-   1.16.2
+   1.17.2

--- a/spec/simplecov/buildkite/annotation_formatter_spec.rb
+++ b/spec/simplecov/buildkite/annotation_formatter_spec.rb
@@ -1,7 +1,13 @@
 require 'spec_helper'
 
 RSpec.describe SimpleCov::Buildkite::AnnotationFormatter do
-  let(:result) { SimpleCov::Result.from_hash("RSpec" => {"coverage" => {"a.rb" => [1, 0], "b.rb" => [0, 1]}, "timestamp" => 1527643747}) }
+  let(:result) do
+    # As of SimpleCov 0.19.0, `SimpleCov::Result.from_hash` now returns an array:
+    # https://github.com/simplecov-ruby/simplecov/commit/9ed35debcd6e5b4a22e99a655c9b40be0d7da142
+    # This is an API intended for internal use, though, and plugins are passed
+    # merged result objects, so we work around this API difference here.
+    SimpleCov::Result.from_hash({"RSpec" => {"coverage" => {"a.rb" => [1, 0], "b.rb" => [0, 1]}, "timestamp" => 1527643747}}).first
+  end
 
   subject(:formatter) { SimpleCov::Buildkite::AnnotationFormatter.new }
 


### PR DESCRIPTION
SimpleCov changed the signature of this internal API, so we need to fix this so specs work with it. This also updates some dependencies.
